### PR TITLE
Add reader api - issue #5

### DIFF
--- a/commit_log/src/position.rs
+++ b/commit_log/src/position.rs
@@ -1,0 +1,4 @@
+pub enum Position {
+    Horizontal, 
+    Offset(usize)
+}

--- a/commit_log/src/record.rs
+++ b/commit_log/src/record.rs
@@ -1,0 +1,38 @@
+
+use super::segment::Segment;
+use super::position::Position;
+use std::io::Error;
+
+pub struct Record<'a> {
+    current_offset: usize,
+
+    segment: &'a mut Segment,
+}
+
+impl<'a> Record<'a> {
+    pub fn new(segment: &'a mut Segment, offset: usize) -> Result<Self, Error>{
+        Ok(Self {
+            current_offset: offset,
+            segment: segment
+        })
+    }
+
+    pub fn record(&mut self) -> Result<&[u8], Error> {
+        self.segment.read_at(self.current_offset)
+    }
+
+    pub fn position(&self) -> Position {
+        Position::Offset(self.current_offset)
+    }
+
+    pub fn record_after(&'a mut self, offset: usize) -> Self {
+        Self {
+            segment: self.segment,
+            current_offset: self.current_offset + offset
+        }
+    }
+
+    pub fn next(&'a mut self) -> Self {
+        self.record_after(1)
+    }
+}


### PR DESCRIPTION
A draft API for reader interface.
Changes:
1. Add field `current_segment` in `commit_log` as pointer to current segment.
2. Add method `read_after` which takes in a `position: Position` and `offset`. It will read the log that is `offset` after `position`
3. Add method `read` which call `read_after(position, 0)`
4. Add struct Record which has two fields `current_offset` and `segment`. Implements `record`, `position`, `record_after`, and `next`.
5. Add enum `Position` 