### PR TITLE
Add reader struct 

### DIFF
--- a/commit_log/src/lib.rs
+++ b/commit_log/src/lib.rs
@@ -2,6 +2,7 @@ extern crate memmap;
 mod segment;
 mod position;
 mod record;
+mod reader;
 
 use self::segment::Segment;
 use position::Position;

--- a/commit_log/src/lib.rs
+++ b/commit_log/src/lib.rs
@@ -105,12 +105,15 @@ impl CommitLog {
 
     pub fn read_after(&mut self, position: Position, mut offset: usize) -> Result<Record, Error> {
         let current_pos = match position {
-            Position::Horizontal => 1,
+            Position::Horizon => 1,
             Position::Offset(offset) => offset
         };
         offset += current_pos;
 
-        return Record::new(&mut self.segments[self.current_segment], offset);
+        Ok(Record {
+            segment_index: self.current_segment,
+            current_offset: offset
+        })
     }
 
 

--- a/commit_log/src/position.rs
+++ b/commit_log/src/position.rs
@@ -1,4 +1,6 @@
 pub enum Position {
+    /// The first entry available.
     Horizon,
+
     Offset(usize)
 }

--- a/commit_log/src/position.rs
+++ b/commit_log/src/position.rs
@@ -1,4 +1,4 @@
 pub enum Position {
-    Horizontal, 
+    Horizon,
     Offset(usize)
 }

--- a/commit_log/src/reader.rs
+++ b/commit_log/src/reader.rs
@@ -1,0 +1,28 @@
+use super::record::Record;
+
+pub struct Reader {
+    commit_log: &CommitLog
+}
+
+impl Reader {
+
+    pub fn record(&mut self, record: Record) -> Result<&[u8], Error> {
+        let segment = self.commit_log.segment[record.segment_index];
+        segment.read_at(record.current_offset)
+    }
+
+    pub fn position(record: Record) -> Position {
+        Position::Offset(record.current_offset)
+    }
+
+    pub fn record_after(record: Record) -> Record {
+        Record {
+            segment_index: record.segment_index,
+            current_offset: record.current_offset + offset
+        }
+    }
+
+    pub fn next(record: Record) -> Record {
+        Reader::record_after(1)
+    }
+}

--- a/commit_log/src/reader.rs
+++ b/commit_log/src/reader.rs
@@ -1,28 +1,46 @@
 use super::record::Record;
+use super::CommitLog;
+use super::position::Position;
+use std::result::Result;
+use std::io::Error;
 
-pub struct Reader {
-    commit_log: &CommitLog
+pub struct Reader<'a> {
+    commit_log: &'a CommitLog
 }
 
-impl Reader {
+impl<'a> Reader<'a> {
 
-    pub fn record(&mut self, record: Record) -> Result<&[u8], Error> {
-        let segment = self.commit_log.segment[record.segment_index];
+    /// Read the log according to record's information.
+    ///
+    /// # Arguments
+    /// * `record` - A Record to be read.
+    pub fn read(& mut self, record: Record) -> Result<&[u8], Error> {
+        let segment = &self.commit_log.segments[record.segment_index];
         segment.read_at(record.current_offset)
     }
 
+    /// Read the position of one record
+    ///
+    /// # Arguments
+    /// * `record` - A Record to be read.
     pub fn position(record: Record) -> Position {
         Position::Offset(record.current_offset)
     }
 
-    pub fn record_after(record: Record) -> Record {
+    /// Get record information after number of offset.
+    ///
+    /// # Arguments
+    /// * `record` - the current record.
+    /// * `offset` - the offset from expected record to current record.
+    pub fn record_after(record: Record, offset: usize) -> Record {
         Record {
             segment_index: record.segment_index,
             current_offset: record.current_offset + offset
         }
     }
 
+    /// Get the next record's information.
     pub fn next(record: Record) -> Record {
-        Reader::record_after(1)
+        Reader::record_after(record, 1)
     }
 }

--- a/commit_log/src/record.rs
+++ b/commit_log/src/record.rs
@@ -1,38 +1,4 @@
-
-use super::segment::Segment;
-use super::position::Position;
-use std::io::Error;
-
-pub struct Record<'a> {
-    current_offset: usize,
-
-    segment: &'a mut Segment,
-}
-
-impl<'a> Record<'a> {
-    pub fn new(segment: &'a mut Segment, offset: usize) -> Result<Self, Error>{
-        Ok(Self {
-            current_offset: offset,
-            segment: segment
-        })
-    }
-
-    pub fn record(&mut self) -> Result<&[u8], Error> {
-        self.segment.read_at(self.current_offset)
-    }
-
-    pub fn position(&self) -> Position {
-        Position::Offset(self.current_offset)
-    }
-
-    pub fn record_after(&'a mut self, offset: usize) -> Self {
-        Self {
-            segment: self.segment,
-            current_offset: self.current_offset + offset
-        }
-    }
-
-    pub fn next(&'a mut self) -> Self {
-        self.record_after(1)
-    }
+pub struct Record {
+    pub current_offset: usize,
+    pub segment_index: usize,
 }

--- a/commit_log/src/record.rs
+++ b/commit_log/src/record.rs
@@ -1,4 +1,7 @@
 pub struct Record {
+    /// The current offset within current segment.
     pub current_offset: usize,
+
+    /// Index to current segment.
     pub segment_index: usize,
 }

--- a/commit_log/src/segment.rs
+++ b/commit_log/src/segment.rs
@@ -64,7 +64,7 @@ impl Segment {
     }
 
     /// Read the log at a given index offset
-    pub fn read_at(&mut self, offset: usize) -> Result<&[u8], Error> {
+    pub fn read_at(&self, offset: usize) -> Result<&[u8], Error> {
         let entry = self.index.read_at(offset)?;
 
         self.log.read_at(entry.offset, entry.size)

--- a/commit_log/src/segment/index.rs
+++ b/commit_log/src/segment/index.rs
@@ -103,7 +103,7 @@ impl Index {
     }
 
     /// Read an entry from the index
-    pub fn read_at(&mut self, offset: usize) -> Result<(Entry), Error> {
+    pub fn read_at(&self, offset: usize) -> Result<(Entry), Error> {
         let real_offset = offset * ENTRY_SIZE;
 
         if (real_offset + ENTRY_SIZE) >= self.mmap.len() {

--- a/commit_log/src/segment/log.rs
+++ b/commit_log/src/segment/log.rs
@@ -99,7 +99,7 @@ impl Log {
 
     //TODO read from the segment mmap reader
     /// Read the log on a specific position
-    pub fn read_at(&mut self, offset: usize, size: usize) -> Result<&[u8], Error> {
+    pub fn read_at(&self, offset: usize, size: usize) -> Result<&[u8], Error> {
         if (offset + size) > self.mmap.len() {
             return Err(Error::new(
                 ErrorKind::Other,


### PR DESCRIPTION
Add one `Reader` struct to implement `record`, `position`, `record_after`, and `next`.

change 
```rust
read_at(&mut self, offset: usize)
``` 
to 
```rust
read_at(& self, offset: usize)
```
in `log`, `index`, and `segment` (feel it is unnecessary since read is not changing anything, could be wrong)